### PR TITLE
add github workflow to release and lint crate

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,22 @@
+name: Rust Lint
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Run cargo check
+        run: cargo check
+
+      - name: Run cargo clippy
+        run: cargo clippy -- -D warnings

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,67 @@
+name: Release ockam_ebpf
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch_name:
+        description: 'Branch name'
+        required: true
+
+permissions: 
+  contents: write
+
+env:
+  BINARY_ROOT_PATH: ockam_ebpf_impl
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@3ebd1aebb47f95493b62de6eec0cac3cd74e50a9
+
+      - name: Checkout Repository
+        uses: actions/checkout@cbb722410c2e876e24abbe8de2cc27693e501dcb
+
+      - name: Build ockam_ebpf crate
+        shell: nix shell nixpkgs#llvm nixpkgs#rustup nixpkgs#cargo --command bash {0}
+        working-directory: ${{ env.BINARY_ROOT_PATH }}
+        run: |
+          rustup install stable
+          rustup toolchain install nightly --component rust-src
+          cargo install bpf-linker
+          cargo build --release
+
+      - name: Get Latest Version Of Ockam Draft
+        shell: nix shell nixpkgs#gh --command bash {0}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ockam_version=$(gh release list -R ${{ github.repository_owner }}/ockam --json tagName | jq -r '.[0].tagName')
+          ockam_version="${ockam_version#ockam_}"
+          echo "Latest version of Ockam is $ockam_version"
+          echo "ockam_version=$ockam_version" >> $GITHUB_ENV
+
+      - name: Create Release
+        working-directory: ${{ env.BINARY_ROOT_PATH }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Creating release ${{ env.ockam_version }}"
+          gh release create ${{ env.ockam_version }} ./target/bpfel-unknown-none/release/ockam_ebpf -t ${{ env.ockam_version }} -n "Release ${{ env.ockam_version }}"
+
+      - name: Update Version in Cargo.toml
+        shell: nix shell nixpkgs#rustup nixpkgs#cargo nixpkgs#gh --command bash {0}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cargo install cargo-edit --version 0.13.0
+          cargo set-version ${{ env.ockam_version }}
+
+          gh auth setup-git
+          git add --all
+          git commit -m "Bump version to ${{ env.ockam_version }}"
+          # Create a new branch with the version bump
+          git checkout -b "${{ github.event.inputs.branch_name }}"
+          git push origin "${{ github.event.inputs.branch_name }}"

--- a/.github/workflows/release_crate.yml
+++ b/.github/workflows/release_crate.yml
@@ -1,0 +1,21 @@
+name: Crates.io Publish
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-20.04
+    environment: release
+
+    steps:
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@3ebd1aebb47f95493b62de6eec0cac3cd74e50a9
+
+      - name: Checkout Repository
+        uses: actions/checkout@cbb722410c2e876e24abbe8de2cc27693e501dcb
+
+      - name: Crates Publish
+        shell: nix shell nixpkgs#rustup nixpkgs#cargo --command bash {0}
+        run: |
+          cargo publish --token ${{ secrets.CRATES_IO_TOKEN }}

--- a/.github/workflows/release_github.yml
+++ b/.github/workflows/release_github.yml
@@ -1,11 +1,7 @@
-name: Release ockam_ebpf
+name: Github Asset Release
 
 on:
   workflow_dispatch:
-    inputs:
-      branch_name:
-        description: 'Branch name'
-        required: true
 
 permissions: 
   contents: write
@@ -15,7 +11,8 @@ env:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
+    environment: release
 
     steps:
       - name: Install Nix
@@ -57,11 +54,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cargo install cargo-edit --version 0.13.0
-          cargo set-version ${{ env.ockam_version }}
+          cargo set-version --bump minor
 
           gh auth setup-git
           git add --all
-          git commit -m "Bump version to ${{ env.ockam_version }}"
+
+          release_name="release_$(date +'%d-%m-%Y')_$(date +'%s')"
+
+          git commit -m "Bump crate version"
           # Create a new branch with the version bump
-          git checkout -b "${{ github.event.inputs.branch_name }}"
-          git push origin "${{ github.event.inputs.branch_name }}"
+          git checkout -b "$release_name"
+          git push origin "$release_name"


### PR DESCRIPTION
This PR allows us to independently publish the ockam_ebpf crate to the cargo registry and also build and upload the ebpf binary as a github release asset