### PR TITLE
fix: rename `Cargo.toml` -> `Cargo.toml.hidden` to fix cargo behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ vendor
 # nix build
 /result*
 .home
+/ockam_ebpf_impl/Cargo.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,6 +115,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,6 +378,7 @@ dependencies = [
 name = "ockam_ebpf"
 version = "0.5.0"
 dependencies = [
+ "fs_extra",
  "reqwest",
  "url",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,12 @@ eBPF program used by Ockam Privileged Portals
 [features]
 default = []
 # Build eBPF instead of downloading from artifacts
-build = []
+build = ["fs_extra"]
 logging = []
 
 [build-dependencies]
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-native-roots", "blocking"] }
 url = { version = "2.5.2" }
+fs_extra = { version = "1.3.0", optional = true }
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,63 @@
-# ockam-ebpf
+# ockam_ebpf
+
+[![crate][crate-image]][crate-link]
+[![docs][docs-image]][docs-link]
+[![license][license-image]][license-link]
+[![discuss][discuss-image]][discuss-link]
+
+Ockam is a library for building devices that communicate securely, privately
+and trustfully with cloud services and other devices.
+
+This crate contains the eBPF part of Ockam Reliable TCP Portals.
+
+### Build
+
+This crate exposes eBPF binary through the `EBPF_BINARY` static constant in the root of the crate. That binary can be
+used to attach Ockam eBPF to network devices.
+
+### Features
+
+By default, this crate ships a prebuilt eBPF binary downloaded from the corresponding GitHub release artifacts. This
+allows to build Ockam without all the dependencies that are required to build eBPF.
+
+ * build - build the eBPF locally instead of downloading the prebuilt binary. This might be useful during development and debugging.
+ * logging - this will enable logs for eBPF. Note that eBPF sends logs to the user space using `AsyncPerfEventArray`, therefore it implies performance penalty.
+
+```bash
+cargo build
+```
+
+### Requirements to build eBPF
+
+Please refer to [ockam_ebpf_impl/README.md](ockam_ebpf_impl/README.md)
+
+### Requirements to use eBPF
+
+Using ockam with eBPFs requires:
+ - Linux
+ - root (CAP_BPF, CAP_NET_RAW, CAP_NET_ADMIN, CAP_SYS_ADMIN)
+
+## Usage
+
+Add this to your `Cargo.toml`:
+
+```
+[dependencies]
+ockam_ebpf = "0.5.0"
+```
+
+## License
+
+This code is licensed under the terms of the [Apache License 2.0][license-link].
+
+[crate-image]: https://img.shields.io/crates/v/ockam_ebpf.svg
+[crate-link]: https://crates.io/crates/ockam_ebpf
+
+[docs-image]: https://docs.rs/ockam_ebpf/badge.svg
+[docs-link]: https://docs.rs/ockam_ebpf
+
+[license-image]: https://img.shields.io/badge/License-Apache%202.0-green.svg
+[license-link]: https://github.com/build-trust/ockam/blob/HEAD/LICENSE
+
+[discuss-image]: https://img.shields.io/badge/Discuss-Github%20Discussions-ff70b4.svg
+[discuss-link]: https://github.com/build-trust/ockam/discussions

--- a/ockam_ebpf_impl/Cargo.toml.hidden
+++ b/ockam_ebpf_impl/Cargo.toml.hidden
@@ -1,3 +1,4 @@
+[workspace]
 [package]
 name = "ockam_ebpf_impl"
 version = "0.1.0"
@@ -7,9 +8,9 @@ edition = "2021"
 homepage = "https://github.com/build-trust/ockam"
 keywords = ["ockam", "crypto", "p2p", "cryptography", "encryption"]
 license = "Apache-2.0"
-publish = true
+publish = false
 readme = "README.md"
-repository = "https://github.com/build-trust/ockam/implementations/rust/ockam/ockam_ebpf"
+repository = "https://github.com/build-trust/ockam-ebpf/ockam_ebpf_impl"
 rust-version = "1.70.0"
 description = """
 eBPF program used by Ockam Privileged Portals

--- a/ockam_ebpf_impl/README.md
+++ b/ockam_ebpf_impl/README.md
@@ -1,64 +1,25 @@
-# ockam_ebpf
+# ockam_ebpf_impl
 
-[![crate][crate-image]][crate-link]
-[![docs][docs-image]][docs-link]
-[![license][license-image]][license-link]
-[![discuss][discuss-image]][discuss-link]
-
-Ockam is a library for building devices that communicate securely, privately
-and trustfully with cloud services and other devices.
-
-This crate contains the eBPF part of Ockam Reliable TCP Portals.
+This crate is shipped as a part of `ockam_ebpf` crate rather than a stand-alone crate. Please refer to the ../README.md
+for more information.
 
 ### Build
 
+In order to build the crate it's required to copy `Cargo.toml.hidden` file and rename it to `Cargo.toml`. Note, that
+`Cargo.toml` file is added to `.gitignore` and shouldn't be commited, instead all changes should be inside
+`Cargo.toml.hidden` file. The reason for that is special cargo behaviour that doesn't allow including other crates as
+part of a crate. Therefore, if `ockam_ebpf_impl` subdirectory has `Cargo.toml` file, that directory will be completely
+ignored during `ockam_ebpf` crate release even if it's added to `include` field of root `Cargo.toml`.
+
 ```bash
-cargo build-ebpf
+cargo build
 ```
+### Requirements
 
 Building eBPFs have roughly following requirements:
  - Linux
  - Rust nightly
  - Some dependencies to be installed
 
-Because of that crate with the eBPF code is kept out of the workspace.
-Example of a virtual machine to build it can be found in `ubuntu_x86.yaml`.
-
-Using ockam with eBPFs requires:
- - Linux
- - root (CAP_BPF, CAP_NET_RAW, CAP_NET_ADMIN, CAP_SYS_ADMIN)
-
-Example of a virtual machine to run ockam with eBPF can be found in `ubuntu_arm.yaml`.
-
-eBPF is a small architecture-independent object file that is small enough,
-to include it in the repo.
-
-The built eBPF object should be copied to `/implementations/rust/ockam/ockam_ebpf/ockam_ebpf`,
-from where it will be grabbed by `ockam_transport_tcp` crate.
-
-## Usage
-
-Add this to your `Cargo.toml`:
-
-```
-[dependencies]
-ockam_ebpf = "0.1.0"
-```
-
-## License
-
-This code is licensed under the terms of the [Apache License 2.0][license-link].
-
-[main-ockam-crate-link]: https://crates.io/crates/ockam
-
-[crate-image]: https://img.shields.io/crates/v/ockam_ebpf.svg
-[crate-link]: https://crates.io/crates/ockam_ebpf
-
-[docs-image]: https://docs.rs/ockam_ebpf/badge.svg
-[docs-link]: https://docs.rs/ockam_ebpf
-
-[license-image]: https://img.shields.io/badge/License-Apache%202.0-green.svg
-[license-link]: https://github.com/build-trust/ockam/blob/HEAD/LICENSE
-
-[discuss-image]: https://img.shields.io/badge/Discuss-Github%20Discussions-ff70b4.svg
-[discuss-link]: https://github.com/build-trust/ockam/discussions
+Because of that, crate with the eBPF code is kept out of the workspace.
+Example of a virtual machine to build and run eBPF can be found in [ubuntu_arm.yaml](../vm/ubuntu_arm.yaml)


### PR DESCRIPTION
Unfortunately, if Cargo.toml file is found in a crate's subdirectory, that subdirectory is completely ignored during the root crate's release and is not included when we pull the root crate as a dependency. This required few workarounds to fix.